### PR TITLE
changed support links to point to ascending domains

### DIFF
--- a/ui/components/ui/sidebar/menu.tsx
+++ b/ui/components/ui/sidebar/menu.tsx
@@ -174,7 +174,7 @@ export const Menu = ({ isOpen }: { isOpen: boolean }) => {
           <>
             <Divider orientation="vertical" />
             <Link
-              href="https://status.prowler.com"
+              href="https://comp.ascendingdc.com/api/v1/docs"
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-1"

--- a/ui/lib/menu-list.ts
+++ b/ui/lib/menu-list.ts
@@ -162,7 +162,7 @@ export const getMenuList = (pathname: string): GroupProps[] => {
           icon: SupportIcon,
           submenus: [
             {
-              href: "https://ascending.atlassian.net/wiki/spaces/ASC/pages/771555329/Prowler+API+Usage",
+              href: "https://comp.ascendingdc.com/api/v1/docs",
               target: "_blank",
               label: "Documentation",
               icon: DocIcon,
@@ -177,7 +177,7 @@ export const getMenuList = (pathname: string): GroupProps[] => {
               icon: APIdocIcon,
             },
             {
-              href: "https://github.com/ascending-llc/cto-scanner/issues",
+              href: "https://ascendingdc.com/about/contact-us?m=Inquiry:%20CTO-Scanner%20Support&p=https://comp.ascendingdc.com",
               target: "_blank",
               label: "Support",
               icon: CircleHelpIcon,

--- a/ui/lib/menu-list.ts
+++ b/ui/lib/menu-list.ts
@@ -162,7 +162,7 @@ export const getMenuList = (pathname: string): GroupProps[] => {
           icon: SupportIcon,
           submenus: [
             {
-              href: "https://docs.prowler.com/",
+              href: "https://ascending.atlassian.net/wiki/spaces/ASC/pages/771555329/Prowler+API+Usage",
               target: "_blank",
               label: "Documentation",
               icon: DocIcon,
@@ -170,14 +170,14 @@ export const getMenuList = (pathname: string): GroupProps[] => {
             {
               href:
                 process.env.NEXT_PUBLIC_IS_CLOUD_ENV === "true"
-                  ? "https://api.prowler.com/api/v1/docs"
+                  ? "https://comp.ascendingdc.com/api/v1/docs"
                   : `${process.env.NEXT_PUBLIC_API_DOCS_URL}`,
               target: "_blank",
               label: "API reference",
               icon: APIdocIcon,
             },
             {
-              href: "https://github.com/prowler-cloud/prowler/issues",
+              href: "https://github.com/ascending-llc/cto-scanner/issues",
               target: "_blank",
               label: "Support",
               icon: CircleHelpIcon,

--- a/ui/lib/menu-list.ts
+++ b/ui/lib/menu-list.ts
@@ -177,7 +177,7 @@ export const getMenuList = (pathname: string): GroupProps[] => {
               icon: APIdocIcon,
             },
             {
-              href: "https://ascendingdc.com/about/contact-us?m=Inquiry:%20CTO-Scanner%20Support&p=https://comp.ascendingdc.com",
+              href: "https://ascendingdc.com/about/contact-us?m=Inquiry:%20CTO-Scanner%20Support&p=https%3A%2F%2Fcomp.ascendingdc.com",
               target: "_blank",
               label: "Support",
               icon: CircleHelpIcon,

--- a/ui/lib/menu-list.ts
+++ b/ui/lib/menu-list.ts
@@ -177,7 +177,7 @@ export const getMenuList = (pathname: string): GroupProps[] => {
               icon: APIdocIcon,
             },
             {
-              href: "https://ascendingdc.com/about/contact-us?m=Inquiry%3a%20CTO-Scanner%20Support&p=https%3a%2f%2fcomp.ascendingdc.com",
+              href: "https://ascendingdc.com/about/contact-us?m=Inquiry:%20CTO-Scanner%20Support&p=/cto-scanner",
               target: "_blank",
               label: "Support",
               icon: CircleHelpIcon,

--- a/ui/lib/menu-list.ts
+++ b/ui/lib/menu-list.ts
@@ -177,7 +177,7 @@ export const getMenuList = (pathname: string): GroupProps[] => {
               icon: APIdocIcon,
             },
             {
-              href: "https://ascendingdc.com/about/contact-us?m=Inquiry:%20CTO-Scanner%20Support&p=https%3A%2F%2Fcomp.ascendingdc.com",
+              href: "https://ascendingdc.com/about/contact-us?m=Inquiry%3a%20CTO-Scanner%20Support&p=https%3a%2f%2fcomp.ascendingdc.com",
               target: "_blank",
               label: "Support",
               icon: CircleHelpIcon,


### PR DESCRIPTION
changed where links are pointing to in

@ryohang 

![image](https://github.com/user-attachments/assets/9c58c481-bd4f-43e7-b1bc-d1cddd2f4409)

note: Existing deployment may not have NEXT_PUBLIC_API_DOCS_URL pointing to https://comp.ascendingdc.com/api/v1/docs
