### PR TITLE
Increase worker node memory limits

### DIFF
--- a/contrib/k8s/helm/prowler-api/values.yaml
+++ b/contrib/k8s/helm/prowler-api/values.yaml
@@ -157,7 +157,7 @@ worker:
       memory: "256Mi"
       cpu: "250m"
     limits:
-      memory: "512Mi"
+      memory: "3Gi"
       cpu: "500m"
 
 workerBeat:


### PR DESCRIPTION
worker node would constanty experience an OOM error, and stall on scans.