### PR TITLE
fixed worker and worker beat versions

### DIFF
--- a/contrib/k8s/helm/prowler-api/values.yaml
+++ b/contrib/k8s/helm/prowler-api/values.yaml
@@ -139,7 +139,7 @@ worker:
   replicaCount: 1
   image:
     repository: prowlercloud/prowler-api
-    tag: stable
+    tag: 5.7.5
     pullPolicy: IfNotPresent
   command: ["/home/prowler/docker-entrypoint.sh", "worker"]
   ports:
@@ -165,7 +165,7 @@ workerBeat:
   replicaCount: 1
   image:
     repository: prowlercloud/prowler-api
-    tag: stable
+    tag: 5.7.5
     pullPolicy: IfNotPresent
   command: ["../docker-entrypoint.sh", "beat"]
   ports:

--- a/terraform/prowler.yaml
+++ b/terraform/prowler.yaml
@@ -139,7 +139,7 @@ worker:
   replicaCount: 1
   image:
     repository: prowlercloud/prowler-api
-    tag: stable
+    tag: 5.7.5
     pullPolicy: IfNotPresent
   command: ["/home/prowler/docker-entrypoint.sh", "worker"]
   ports:
@@ -158,7 +158,7 @@ workerBeat:
   replicaCount: 1
   image:
     repository: prowlercloud/prowler-api
-    tag: stable
+    tag: 5.7.5
     pullPolicy: IfNotPresent
   command: ["../docker-entrypoint.sh", "beat"]
   ports:


### PR DESCRIPTION
@ryohang 

I had forgotten to fix the versions for worker and worker beat in the previous pull request.

Compliance is now properly being generated for scans.

<img width="1557" height="854" alt="image" src="https://github.com/user-attachments/assets/a560401b-b6f8-4ba4-98b4-25937728ab81" />
